### PR TITLE
Add implementations of readField to custom ParseField instances

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ mkDerivation {
     base neat-interpolation optparse-applicative optparse-generic text
     turtle
   ];
-  homepage = "https://github.com/awakesecurity/deploy";
+  homepage = "https://github.com/awakesecurity/nix-deploy#readme";
   description = "Deploy Nix-built software to a NixOS machine";
   license = stdenv.lib.licenses.asl20;
 }

--- a/nix-deploy.cabal
+++ b/nix-deploy.cabal
@@ -35,7 +35,7 @@ executable nix-deploy
               , optparse-applicative >= 0.13.0.0 && < 0.15
               , neat-interpolation                  < 0.4
               , text                 >= 0.7      && < 1.3
-              , turtle               >= 1.3.3    && < 1.4.3
+              , turtle               >= 1.3.6    && < 1.4.3
   default-language:    Haskell2010
 
 source-repository head

--- a/nix/optparse-applicative.nix
+++ b/nix/optparse-applicative.nix
@@ -1,14 +1,14 @@
-{ mkDerivation, ansi-wl-pprint, base, process, QuickCheck, stdenv
-, transformers, transformers-compat
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
 }:
 mkDerivation {
   pname = "optparse-applicative";
-  version = "0.13.0.0";
-  sha256 = "1b0c5fdq8bd070g24vrjrwlq979r8dk8mys6aji9hy1l9pcv3inf";
+  version = "0.14.0.0";
+  sha256 = "06iwp1qsq0gjhnhxwyhdhldwvhlgcik6lx5jxpbb40fispyk4nxm";
   libraryHaskellDepends = [
     ansi-wl-pprint base process transformers transformers-compat
   ];
-  testHaskellDepends = [ base QuickCheck ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
   homepage = "https://github.com/pcapriotti/optparse-applicative";
   description = "Utilities and combinators for parsing command line options";
   license = stdenv.lib.licenses.bsd3;

--- a/nix/optparse-generic.nix
+++ b/nix/optparse-generic.nix
@@ -4,8 +4,8 @@
 }:
 mkDerivation {
   pname = "optparse-generic";
-  version = "1.2.2";
-  sha256 = "110jil2n945x30d8wgdrgs7di310z9hdnzhw5c1zq2jfh3b54ygz";
+  version = "1.2.3";
+  sha256 = "1wxzpj4xj3bafg3piarwsr69xxzp75fdglx9c3spbahl1aq9wzgk";
   libraryHaskellDepends = [
     base bytestring Only optparse-applicative semigroups
     system-filepath text time transformers void

--- a/nix/turtle.nix
+++ b/nix/turtle.nix
@@ -1,20 +1,21 @@
 { mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
-, directory, doctest, foldl, hostname, managed, optional-args
-, optparse-applicative, process, semigroups, stdenv, stm
-, system-fileio, system-filepath, temporary, text, time
+, criterion, directory, doctest, foldl, hostname, managed
+, optional-args, optparse-applicative, process, semigroups, stdenv
+, stm, system-fileio, system-filepath, temporary, text, time
 , transformers, unix, unix-compat
 }:
 mkDerivation {
   pname = "turtle";
-  version = "1.3.3";
-  sha256 = "07jd62b0m1a5g32rl3lgqcwhj8zk3s4gcnqy0c7yiqww7z8nz8c2";
+  version = "1.3.6";
+  sha256 = "0fr8p6rnk2lrsgbfh60jlqcjr0nxrh3ywxsj5d4psck0kgyhvg1m";
   libraryHaskellDepends = [
     ansi-wl-pprint async base bytestring clock directory foldl hostname
     managed optional-args optparse-applicative process semigroups stm
     system-fileio system-filepath temporary text time transformers unix
     unix-compat
   ];
-  testHaskellDepends = [ base doctest ];
+  testHaskellDepends = [ base doctest system-filepath temporary ];
+  benchmarkHaskellDepends = [ base criterion text ];
   description = "Shell programming, Haskell-style";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -70,6 +70,7 @@ data SwitchMethod
     deriving (Eq, Show, ParseFields)
 
 instance ParseField SwitchMethod where
+  readField = Options.readerError "Internal, fatal error: unexpected use of readField"
   parseField _ _ _ =
         Options.flag' Switch      (Options.long "switch")
     <|> Options.flag' Boot        (Options.long "boot")
@@ -91,6 +92,7 @@ data Direction = To Line | From Line
   deriving (Show, ParseFields)
 
 instance ParseField Direction where
+  readField = Options.readerError "Internal, fatal error: unexpected use of readField"
   parseField _ _ _ = (To <$> parseTo) <|> (From <$> parseFrom)
     where
       parseTo    = parser "to" "Deploy software to this address (ex: user@192.168.0.1)"
@@ -113,6 +115,7 @@ instance ParseRecord Line where
 instance ParseFields Line where
 
 instance ParseField Line where
+  readField = Options.maybeReader (textToLine . Text.pack)
   parseField h m c = do
     let metavar = "LINE"
     let line    = Options.maybeReader (textToLine . Text.pack)


### PR DESCRIPTION
This change adds `readField` implementations to the custom `ParseField` instances of our custom data types.

This change is necessary because a `readField` implementation is required as-of the `optparse-generic` release of version `1.2.3`. The `readField` implementation requirement was introduced into `optparse-generic` by [this pull request](https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/pull/44).

Note that this pull request supersedes #6 which is a more involved change set fixing the same issue. This PR supersedes that one because I think we should fix the immediate issue first with as few major code changes as possible.