### PR TITLE
Enable ssh keep live in issuing the reboot command.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -297,7 +297,7 @@ $excText1
 
 
 rebootCmd :: MonadIO io => Text -> io Turtle.ExitCode
-rebootCmd target = Turtle.shell [text|ssh $target sudo reboot|] empty
+rebootCmd target = Turtle.shell [text|ssh -o 'ServerAliveInterval=1' $target sudo reboot|] empty
 
 pathFromStdin :: IO Text
 pathFromStdin = do


### PR DESCRIPTION
When '--reboot' is given, `nix-deploy` will issue the reboot command via
ssh as the last step.  During reboot, systemd may terminate network interface
before the sshd service.  And there is no way for the `nix-deploy` to quickly
detect the connection loss.

To allow fast detection, this commit enables the ssh keep-live feature and
configure the interval to one second.