### PR TITLE
Update to nixos-unstable (673aea9f84c955c94b105797fdc56007017af4db)

### DIFF
--- a/nix-deploy.cabal
+++ b/nix-deploy.cabal
@@ -32,9 +32,9 @@ executable nix-deploy
   build-depends:
                 base                 >= 4.9.0.0  && < 5
               , bytestring           >= 0.10.8.1 && < 1.0
-              , optparse-generic     >= 1.2.0    && < 1.4
+              , optparse-generic     >= 1.4.0    && < 1.5
               , optparse-applicative >= 0.13.0.0 && < 0.17
-              , neat-interpolation                  < 0.4
+              , neat-interpolation                  < 0.6
               , text                 >= 0.7      && < 1.3
               , turtle               >= 1.3.6    && < 1.6
   default-language:    Haskell2010

--- a/release.nix
+++ b/release.nix
@@ -1,7 +1,7 @@
 let
   pinnedNixpkgs = builtins.fetchTarball {
-    url    = "https://github.com/NixOS/nixpkgs/archive/7c06b2145ddc21a20c7f178c3391bdaf8497fae2.tar.gz";
-    sha256 = "1a0aaybapbcv39dvji0l138lvwimyr9skx5mz88y65ysf7zvlpwi";
+    url    = "https://github.com/NixOS/nixpkgs/archive/673aea9f84c955c94b105797fdc56007017af4db.tar.gz";
+    sha256 = "13zzzsjky30hyj2mm3m8pdna4qyajpa8c40aagx4w9rz1x5h4m6y";
   };
 
 in

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -83,7 +83,7 @@ data SwitchMethod
 
 instance ParseField SwitchMethod where
   readField = Options.readerError "Internal, fatal error: unexpected use of readField"
-  parseField _ _ _ =
+  parseField _ _ _ _ =
         Options.flag' Switch      (Options.long "switch")
     <|> Options.flag' Boot        (Options.long "boot")
     <|> Options.flag' Test        (Options.long "test")
@@ -105,7 +105,7 @@ data Direction = To Line | From Line
 
 instance ParseField Direction where
   readField = Options.readerError "Internal, fatal error: unexpected use of readField"
-  parseField _ _ _ = (To <$> parseTo) <|> (From <$> parseFrom)
+  parseField _ _ _ _ = (To <$> parseTo) <|> (From <$> parseFrom)
     where
       parseTo    = parser "to" "Deploy software to this address (ex: user@192.168.0.1)"
       parseFrom  = parser "from" "Deploy software from this address (ex: user@192.168.0.1)"
@@ -128,7 +128,7 @@ instance ParseFields Line where
 
 instance ParseField Line where
   readField = Options.maybeReader (textToLine . Text.pack)
-  parseField h m c = do
+  parseField h m c _ = do
     let metavar_ = "LINE"
     let line     = Options.maybeReader (textToLine . Text.pack)
 


### PR DESCRIPTION
nixos-21.05 isn’t released yet, but this is still useful for anyone
needing nix-deploy on macOS big sur.